### PR TITLE
Update access URL in README from port 8089 to 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ cd PriceGhost
 # Start all services
 docker-compose up -d
 
-# Access at http://localhost:8089
+# Access at http://localhost:80
 ```
 
 ### Environment Variables


### PR DESCRIPTION
The docker-compose.yml configures client api to be exposed at the default port(80) , not 8089