### PR TITLE
fix: avoid recording a duplicate price_history row on every scheduled check

### DIFF
--- a/backend/src/services/scheduler.ts
+++ b/backend/src/services/scheduler.ts
@@ -105,8 +105,11 @@ async function checkPrices(): Promise<void> {
           // Get the latest recorded price to compare
           const latestPrice = await priceHistoryQueries.getLatest(product.id);
 
-          // Only record if price has changed or it's the first entry
-          if (!latestPrice || latestPrice.price !== scrapedData.price.price) {
+          // Only record if price has changed or it's the first entry.
+          // latestPrice.price comes back from pg as a string (DECIMAL), while
+          // scrapedData.price.price is a number, so a raw !== is always true;
+          // coerce first (as the notification checks below already do).
+          if (!latestPrice || parseFloat(String(latestPrice.price)) !== scrapedData.price.price) {
             // Check for price drop notification before recording
             if (latestPrice && product.price_drop_threshold) {
               const oldPrice = parseFloat(String(latestPrice.price));


### PR DESCRIPTION
## Summary

The scheduler's dedup guard never matches, so an identical `price_history` row is written on **every** scheduled check even when the price hasn't changed.

`backend/src/services/scheduler.ts`:

```ts
const latestPrice = await priceHistoryQueries.getLatest(product.id);
// Only record if price has changed or it's the first entry
if (!latestPrice || latestPrice.price !== scrapedData.price.price) {
```

`price_history.price` is `DECIMAL(10,2)`, and `node-postgres` returns `DECIMAL`/`NUMERIC` as a **string** (there's no `pg.types.setTypeParser` in the repo). So `latestPrice.price` is `"19.99"` while `scrapedData.price.price` is the number `19.99`. `!==` does no coercion, so `"19.99" !== 19.99` is always `true` and the guard passes every time.

The intent is clearly to skip unchanged prices — the comment says so and the `else` branch logs `Price unchanged for product ...`, which is currently unreachable. The neighbouring price-drop and target-price checks already coerce with `parseFloat(String(latestPrice.price))`; this one comparison just missed it.

## Impact

At the default 1-hour `refresh_interval`, each product accumulates ~24 identical rows per day. `price_history` grows without bound, the "Price unchanged" optimization is dead code, and the price chart / `price_count` stat get padded with redundant points. (Notifications are unaffected — the drop/target checks use `parseFloat`, so a zero delta correctly fails the threshold.)

## Fix

Coerce the stored value before comparing, matching what the surrounding checks already do:

```ts
if (!latestPrice || parseFloat(String(latestPrice.price)) !== scrapedData.price.price) {
```

An actual price change still records a new row; an unchanged price now correctly hits the `else` branch.

## Testing

The repo has no test harness, so I verified by tracing the runtime types: `getLatest` returns the raw pg row (price as string), `PriceInfo.price` is typed `number` and produced via `parseFloat`, and there is no global decimal type parser. Happy to add a small `priceChanged()` helper + unit test if you'd like a harness set up.